### PR TITLE
Changes to /ptime

### DIFF
--- a/src/net/kineticraft/lostcity/commands/player/CommandPTime.java
+++ b/src/net/kineticraft/lostcity/commands/player/CommandPTime.java
@@ -13,7 +13,7 @@ import org.bukkit.entity.Player;
 public class CommandPTime extends PlayerCommand {
 
     public CommandPTime() {
-        super(EnumRank.SIGMA, "<time|reset>", "Set your local time.", "ptime");
+        super(EnumRank.SIGMA, "<time|sunrise|day|midnight|night|reset>", "Set your local time.", "ptime");
     }
 
     @Override
@@ -22,7 +22,20 @@ public class CommandPTime extends PlayerCommand {
         if(args[0].equalsIgnoreCase("reset")) {
             p.resetPlayerTime();
             sender.sendMessage(ChatColor.GOLD + "Clock synced.");
-        } else {
+        } else if(args[0].equalsIgnoreCase("day")) {
+            p.setPlayerTime(1000L, false);
+            sender.sendMessage( ChatColor.GOLD + "Time set to day.");
+        } else if(args[0].equalsIgnoreCase("night")) {
+            p.setPlayerTime(13000L, false);
+            sender.sendMessage(ChatColor.GOLD + "Time set to night.");
+        } else if(args[0].equalsIgnoreCase("midnight")) {
+            p.setPlayerTime(18000L, false);
+            sender.sendMessage(ChatColor.GOLD + "Time set to midnight.");
+        } else if(args[0].equalsIgnoreCase("sunrise")) {
+            p.setPlayerTime(22916L, false);
+            sender.sendMessage(ChatColor.GOLD + "Time set to sunrise.");
+        }
+        else {
             p.setPlayerTime(Integer.parseInt(args[0]), false);
             sender.sendMessage(ChatColor.GOLD + "Time set to " + ChatColor.RED + args[0]);
         }


### PR DESCRIPTION
Changed /ptime to allow players to do /ptime sunrise|day|night|midnight still allowing them to use numbers if they want to